### PR TITLE
Add cli flag to disable name resolution

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -53,6 +53,7 @@ config_create()
     config->sensor.frequency = 1000;
     config->sensor.cgroup_basepath = "/sys/fs/cgroup/perf_event";
     config->sensor.name = NULL;
+    config->sensor.resolve_names = true;
 
     /* storage default config */
     config->storage.type = STORAGE_CSV;
@@ -121,8 +122,11 @@ config_setup_from_cli(int argc, char **argv, struct config *config)
     zhashx_set_duplicator(config->events.containers, (zhashx_duplicator_fn *) events_group_dup);
     zhashx_set_destructor(config->events.containers, (zhashx_destructor_fn *) events_group_destroy);
 
-    while ((c = getopt(argc, argv, "vf:p:n:s:c:e:or:U:D:C:")) != -1) {
+    while ((c = getopt(argc, argv, "ivf:p:n:s:c:e:or:U:D:C:")) != -1) {
 	switch (c) {
+	    case 'i':
+		config->sensor.resolve_names = false;
+		break;
 	    case 'v':
 		config->sensor.frequency++;
 		break;

--- a/src/config.h
+++ b/src/config.h
@@ -45,6 +45,7 @@ struct config_sensor
     unsigned int verbose;
     unsigned int frequency;
     const char *cgroup_basepath;
+    bool resolve_names;
     const char *name;
 };
 

--- a/src/target.h
+++ b/src/target.h
@@ -62,6 +62,7 @@ struct target
 {
     enum target_type type;
     char *cgroup_path;
+    bool resolve_name;
 };
 
 /*
@@ -77,7 +78,7 @@ int target_validate_type(enum target_type type, const char *cgroup_path);
 /*
  * target_create allocate the resources and configure the target.
  */
-struct target *target_create(enum target_type type, const char *cgroup_path);
+struct target *target_create(enum target_type type, const char *cgroup_path, bool resolve_name);
 
 /*
  * target_resolve_real_name resolve and return the real name of the given target.
@@ -92,7 +93,7 @@ void target_destroy(struct target *target);
 /*
  * target_discover_running returns a list of running targets.
  */
-int target_discover_running(const char *base_path, enum target_type type_mask, zhashx_t *targets);
+int target_discover_running(const char *base_path, enum target_type type_mask, bool resolve_name, zhashx_t *targets);
 
 #endif /* TARGET_H */
 


### PR DESCRIPTION
When using the `-i` flag, containers names are not resolved and reports
use the raw container id.

This works as a workaround for #2 and will be useful in any exotic environment when name resolution is not easy or even not useful (as other metadata must retrieved anyway). 