### PR TITLE
fix: check on wrong return value in addr_init

### DIFF
--- a/src/storage_socket.c
+++ b/src/storage_socket.c
@@ -98,7 +98,7 @@ socket_initialize(struct storage_module *module)
     if (module->is_initialized)
         return -1;
 
-    if(addr_init(ctx->config, &(ctx->address)) == -1){
+    if(addr_init(ctx->config, &(ctx->address)) == 0){
         zsys_error("socket: failed to parse uri: %s", ctx->config.address);
         goto error;
     }


### PR DESCRIPTION
`addr_init` calls `inet_pton`, which returns 0 when the supplied does
string does not represent a valid network address in the specified
address family.
We were checking for -1 instead of 0, missing this error case.
Due to that error, the sensor accepts any value in the socket output
configuration, even invalid ip address, and blocks instead of reporting
an error.  git reset --soft HEAD~1