### PR TITLE
fix memory leak in socket output

### DIFF
--- a/src/storage_socket.c
+++ b/src/storage_socket.c
@@ -299,6 +299,10 @@ static int socket_store_report(struct storage_module *module,
     ret = -1;
   }
 
+  if (buffer != NULL) {
+      bson_free(buffer);
+  }
+
   bson_destroy(&document);
   return ret;
 }


### PR DESCRIPTION
When using `bson_as_json()` the caller is responsible for freeing the
resulting UTF-8 encoded string by calling `bson_free()` with the result.

This fixes #18 .