### PR TITLE
Supports running the sensor with an unprivileged user

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# Check if the capabilities associated to the executable are available from the current Bounding set.
+# The Bounding set is used because the Permitted/Inheritable/Effective sets are cleared when we switch to an unprivileged user in the image.
+#
+REQUIRED_CAP=$(/sbin/getcap /usr/bin/hwpc-sensor |sed -e 's/.*\(cap_.*\)[+=].*$/\1/')
+REQUIRED_CAP_AVAILABLE=$([ -n "${REQUIRED_CAP}" ] && /sbin/capsh --print |grep "Bounding set =" |grep -iqv "${REQUIRED_CAP}" ; echo $?)
+if [ "${REQUIRED_CAP_AVAILABLE}" -eq 0 ]; then
+    echo >&2 "ERROR: This program requires the '${REQUIRED_CAP^^}' capability to work."
+    exit 1
+fi
+
+exec /usr/bin/hwpc-sensor "$@"

--- a/src/perf.h
+++ b/src/perf.h
@@ -119,5 +119,11 @@ void perf_config_destroy(struct perf_config *config);
  */
 void perf_monitoring_actor(zsock_t *pipe, void *args);
 
+/*
+ * perf_try_event_open try to open a global counting event using the perf_event_open syscall.
+ * This is used to check if the perf_event_open syscall is working and the current process is allowed to use it.
+ */
+int perf_try_global_counting_event_open();
+
 #endif /* PERF_H */
 

--- a/src/sensor.c
+++ b/src/sensor.c
@@ -176,9 +176,9 @@ main(int argc, char **argv)
     }
     zsys_info("uname: %s %s %s %s", kernel_info.sysname, kernel_info.release, kernel_info.version, kernel_info.machine);
 
-    /* check if run as root */
-    if (geteuid()) {
-        zsys_error("perms: this program requires to be run as root to work");
+    /* check if perf_event is working */
+    if (perf_try_global_counting_event_open()) {
+        zsys_error("perf: error while testing the perf_event support");
         goto cleanup;
     }
 


### PR DESCRIPTION
PR overview:

- Supports running the sensor with an unprivileged user ;
- Adds a perf_event self-check instead of the root user id check before starting the sensor ;
- Sets the file capability of the executable when building the Docker image ;
- Adds an entrypoint script to the Docker image that check the required/available capabilities before starting the sensor.

Currently, the default capability set to the executable is `CAP_SYS_ADMIN` because most Linux LTS distributions (RHEL 7, Debian 10, Ubuntu 20.04) don't support the more restrictive `CAP_PERFMON` capability available since Linux 5.8. However, this capability can be set when building the image with the `FILE_CAPABILITY` build arg.

To run the sensor with a minimal set of capabilities with Docker:
```
docker run -it --rm --cap-drop ALL --cap-add CAP_SYS_ADMIN powerapi/hwpc-sensor
```

Close: #10 