### PR TITLE
FIX target for kubernetes

### DIFF
--- a/src/target.c
+++ b/src/target.c
@@ -120,6 +120,8 @@ target_create(enum target_type type, const char *cgroup_basedir, const char *cgr
 char *
 target_resolve_real_name(struct target *target)
 {
+    char *target_pod_name = NULL;
+    char *target_container_name = NULL;
     char *target_real_name = NULL;
 
     switch (target->type) {
@@ -128,7 +130,11 @@ target_resolve_real_name(struct target *target)
             break;
 
         case TARGET_TYPE_KUBERNETES:
-            target_real_name = target_kubernetes_resolve_name(target);
+            target_container_name = target_kubernetes_container_id(target->cgroup_path);
+            target_pod_name = target_kubernetes_pod_id(target->cgroup_path);
+            target_real_name = target_kubernetes_global_id(target_pod_name, target_container_name);
+            free(target_container_name);
+            free(target_pod_name);
             break;
 
         case TARGET_TYPE_ALL:

--- a/src/target_kubernetes.h
+++ b/src/target_kubernetes.h
@@ -42,7 +42,11 @@ int target_kubernetes_validate(const char *cgroup_path);
 /*
  * target_kubernetes_resolve_name resolve and return the real name of the given target.
  */
-char *target_kubernetes_resolve_name(struct target *target);
+char *target_kubernetes_container_id(char *cgroup_path);
+
+char *target_kubernetes_pod_id(char *cgroup_path);
+
+char *target_kubernetes_global_id(char *pod_id, char *container_id);
 
 #endif /* TARGET_KUBERNETES_H */
 


### PR DESCRIPTION
Hi,
As i used powerapi inside a kubernetes cluster, i saw that the path for the pod and container's id do not match what is used by k8s. (which doesn't use dockershim anymore but containerd)
Powerapi use path like `perf_event/kubepods/` where it should be `perf_event/kubepods.slice/`. I did some changes to match this pattern. Furthermore, in order to visualize data with Prometheus and Grafana whithout making changes to the formula, I modified the target-real-name to be like " podID-containerID " which is arbitrary as i use it with PromQL to have a consumption by pod and containers. 

Changes:
- Kubernetes path to match containerd
- target real-name for kubernetes 