### PR TITLE
build(CMake): Add CMake find module for libpfm4

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,8 @@ set(CMAKE_C_STANDARD 11)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
+
 add_compile_options(-Werror -Wall -Wextra -Wpedantic -Wformat=2 -Wnull-dereference)
 add_link_options(-Wl,-z,relro,-z,now -pie)
 set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -Og -fsanitize=address,undefined -fno-omit-frame-pointer")
@@ -31,9 +33,9 @@ set(SENSOR_SOURCES
     src/sensor.c
 )
 
+find_package(LibPFM REQUIRED)
 find_package(PkgConfig)
 pkg_check_modules(CZMQ REQUIRED libczmq)
-#pkg_check_modules(PFM REQUIRED libpfm)
 
 if(WITH_MONGODB)
     pkg_check_modules(MONGOC REQUIRED libmongoc-1.0)
@@ -46,5 +48,5 @@ if(DEFINED ENV{GIT_TAG} AND DEFINED ENV{GIT_REV})
 endif()
 
 add_executable(hwpc-sensor "${SENSOR_SOURCES}")
-target_include_directories(hwpc-sensor SYSTEM PRIVATE "${CZMQ_INCLUDE_DIRS}" "${MONGOC_INCLUDE_DIRS}")
-target_link_libraries(hwpc-sensor "${CZMQ_LIBRARIES}" pfm "${MONGOC_LIBRARIES}")
+target_include_directories(hwpc-sensor SYSTEM PRIVATE "${LIBPFM_INCLUDE_DIRS}" "${CZMQ_INCLUDE_DIRS}" "${MONGOC_INCLUDE_DIRS}")
+target_link_libraries(hwpc-sensor "${LIBPFM_LIBRARIES}" "${CZMQ_LIBRARIES}" "${MONGOC_LIBRARIES}")

--- a/cmake/FindLibPFM.cmake
+++ b/cmake/FindLibPFM.cmake
@@ -1,0 +1,25 @@
+# CMake module for libpfm4
+#
+# The following variables will be set after configuration:
+# LIBPFM_FOUND
+# LIBPFM_LIBRARIES
+# LIBPFM_INCLUDE_DIRS
+# LIBPFM_VERSION
+
+include(FeatureSummary)
+include(FindPackageHandleStandardArgs)
+
+find_path(LIBPFM_INCLUDE_DIR NAMES perfmon/pfmlib.h)
+find_library(LIBPFM_LIBRARY NAMES pfm)
+
+# Follow symbolic link and try to extract library version from the .so file.
+get_filename_component(LIBPFM_LIBRARY_REALPATH "${LIBPFM_LIBRARY}" REALPATH)
+string(REGEX MATCH "([0-9]+\\.[0-9]+\\.[0-9]+)$" LIBPFM_VERSION ${LIBPFM_LIBRARY_REALPATH})
+
+find_package_handle_standard_args(LibPFM REQUIRED_VARS LIBPFM_LIBRARY LIBPFM_INCLUDE_DIR VERSION_VAR LIBPFM_VERSION)
+
+if (LIBPFM_FOUND)
+    set(LIBPFM_LIBRARIES "pfm")
+    set(LIBPFM_INCLUDE_DIRS "${LIBPFM_INCLUDE_DIR}")
+    mark_as_advanced(LIBPFM_LIBRARIES LIBPFM_INCLUDE_DIRS LIBPFM_VERSION)
+endif()


### PR DESCRIPTION
This PR adds a CMake find module for the libpfm4 dependency.