### PR TITLE
refactor(storage/socket): Serialize reports with the `json-c` library

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Install dependencies
       run: |
         sudo apt-get update
-        sudo apt-get install -y libczmq-dev libpfm4-dev libmongoc-dev
+        sudo apt-get install -y libczmq-dev libpfm4-dev libjson-c-dev libmongoc-dev
 
     - name: Configure CMake
       run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DCMAKE_C_COMPILER=${{matrix.compiler}} -DCMAKE_C_CLANG_TIDY=clang-tidy

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,7 @@ set(SENSOR_SOURCES
 find_package(LibPFM REQUIRED)
 find_package(PkgConfig)
 pkg_check_modules(CZMQ REQUIRED libczmq)
+pkg_check_modules(JSONC REQUIRED json-c)
 
 if(WITH_MONGODB)
     pkg_check_modules(MONGOC REQUIRED libmongoc-1.0)
@@ -48,5 +49,5 @@ if(DEFINED ENV{GIT_TAG} AND DEFINED ENV{GIT_REV})
 endif()
 
 add_executable(hwpc-sensor "${SENSOR_SOURCES}")
-target_include_directories(hwpc-sensor SYSTEM PRIVATE "${LIBPFM_INCLUDE_DIRS}" "${CZMQ_INCLUDE_DIRS}" "${MONGOC_INCLUDE_DIRS}")
-target_link_libraries(hwpc-sensor "${LIBPFM_LIBRARIES}" "${CZMQ_LIBRARIES}" "${MONGOC_LIBRARIES}")
+target_include_directories(hwpc-sensor SYSTEM PRIVATE "${LIBPFM_INCLUDE_DIRS}" "${CZMQ_INCLUDE_DIRS}" "${JSONC_INCLUDE_DIRS}" "${MONGOC_INCLUDE_DIRS}")
+target_link_libraries(hwpc-sensor "${LIBPFM_LIBRARIES}" "${CZMQ_LIBRARIES}" "${JSONC_LIBRARIES}" "${MONGOC_LIBRARIES}")

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 ARG BUILD_TYPE=Debug
 ARG MONGODB_SUPPORT=ON
 RUN apt update && \
-    apt install -y build-essential git clang-tidy cmake pkg-config libczmq-dev libsystemd-dev uuid-dev && \
+    apt install -y build-essential git clang-tidy cmake pkg-config libczmq-dev libjson-c-dev libsystemd-dev uuid-dev && \
     echo "${MONGODB_SUPPORT}" |grep -iq "on" && apt install -y libmongoc-dev || true
 COPY --from=libpfm-builder /root/libpfm4*.deb /tmp/
 RUN dpkg -i /tmp/libpfm4_*.deb /tmp/libpfm4-dev_*.deb && \
@@ -34,7 +34,7 @@ ARG MONGODB_SUPPORT=ON
 ARG FILE_CAPABILITY=CAP_SYS_ADMIN
 RUN useradd -d /opt/powerapi -m powerapi && \
     apt update && \
-    apt install -y libczmq4 libcap2-bin && \
+    apt install -y libczmq4 libjson-c5 libcap2-bin && \
     echo "${MONGODB_SUPPORT}" |grep -iq "on" && apt install -y libmongoc-1.0-0 || true && \
     echo "${BUILD_TYPE}" |grep -iq "debug" && apt install -y libasan6 libubsan1 || true && \
     rm -rf /var/lib/apt/lists/*

--- a/src/storage_socket.h
+++ b/src/storage_socket.h
@@ -43,13 +43,6 @@
 #define PORT_STR_BUFFER_SIZE 8
 
 /*
- * TIMESTAMP_STR_BUFFER_SIZE stores the maximum lenght of the buffer used to convert
- * the timestamp stored as uint64_t to a null terminated string.
- * It should have enough space to store all digits of UINT64_MAX and the null character.
- */
-#define TIMESTAMP_STR_BUFFER_SIZE 32
-
-/*
  * MAX_DURATION_CONNECTION_RETRY stores the maximal value of a connection retry. (in seconds)
  */
 #define MAX_DURATION_CONNECTION_RETRY 1800


### PR DESCRIPTION
This PR reworks the `socket` storage module to use the `json-c` library to serialize reports instead of `libbson`.