### PR TITLE
feat: Add `msr` PMU events encoding

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,25 +1,11 @@
-# libpfm dependency builder image
-FROM ubuntu:24.04 as libpfm-builder
-ENV DEBIAN_FRONTEND=noninteractive
-RUN apt update && \
-    apt install -y build-essential git devscripts debhelper libncurses-dev && \
-    git clone -b smartwatts https://github.com/gfieni/libpfm4.git /root/libpfm4 && \
-    cd /root/libpfm4 && \
-    sed -i 's/CONFIG_PFMLIB_NOPYTHON=n/CONFIG_PFMLIB_NOPYTHON=y/' debian/rules && \
-    sed -i '/^Package: python-libpfm4$/,/^$/d' debian/control && \
-    fakeroot debian/rules binary
-
 # sensor builder image (build tools + development dependencies):
 FROM ubuntu:24.04 as sensor-builder
 ENV DEBIAN_FRONTEND=noninteractive
 ARG BUILD_TYPE=Debug
 ARG MONGODB_SUPPORT=ON
 RUN apt update && \
-    apt install -y build-essential git clang-tidy cmake pkg-config libczmq-dev libjson-c-dev libsystemd-dev uuid-dev && \
+    apt install -y build-essential git clang-tidy cmake pkg-config libczmq-dev libpfm4-dev libjson-c-dev libsystemd-dev uuid-dev && \
     echo "${MONGODB_SUPPORT}" |grep -iq "on" && apt install -y libmongoc-dev || true
-COPY --from=libpfm-builder /root/libpfm4*.deb /tmp/
-RUN dpkg -i /tmp/libpfm4_*.deb /tmp/libpfm4-dev_*.deb && \
-    rm /tmp/*.deb
 COPY . /usr/src/hwpc-sensor
 RUN cd /usr/src/hwpc-sensor && \
     GIT_TAG=$(git describe --tags --dirty 2>/dev/null || echo "unknown") \
@@ -35,13 +21,10 @@ ARG MONGODB_SUPPORT=ON
 ARG FILE_CAPABILITY=CAP_SYS_ADMIN
 RUN useradd -d /opt/powerapi -m powerapi && \
     apt update && \
-    apt install -y libczmq4 libjson-c5 libcap2-bin && \
+    apt install -y libczmq4 libpfm4 libjson-c5 libcap2-bin && \
     echo "${MONGODB_SUPPORT}" |grep -iq "on" && apt install -y libmongoc-1.0-0 || true && \
     echo "${BUILD_TYPE}" |grep -iq "debug" && apt install -y libasan8 libubsan1 || true && \
     rm -rf /var/lib/apt/lists/*
-COPY --from=libpfm-builder /root/libpfm4*.deb /tmp/
-RUN dpkg -i /tmp/libpfm4_*.deb && \
-    rm /tmp/*.deb
 COPY --from=sensor-builder /usr/src/hwpc-sensor/build/hwpc-sensor /usr/bin/hwpc-sensor
 RUN setcap "${FILE_CAPABILITY}+ep" /usr/bin/hwpc-sensor && \
     setcap -v "${FILE_CAPABILITY}+ep" /usr/bin/hwpc-sensor

--- a/src/util.c
+++ b/src/util.c
@@ -120,7 +120,7 @@ str_to_uint(const char *str, unsigned int *out)
     errno = 0;
     value = strtoul(str, &str_endp, 0);
 
-    if (errno != 0 || str == str_endp || *str_endp != '\0') {
+    if (errno != 0 || str == str_endp || (*str_endp != '\0' && *str_endp != '\n')) {
         return EINVAL;
     }
 
@@ -141,7 +141,7 @@ str_to_int(const char *str, int *out)
     errno = 0;
     value = strtol(str, &str_endp, 0);
 
-    if (errno != 0 || str == str_endp || *str_endp != '\0') {
+    if (errno != 0 || str == str_endp || (*str_endp != '\0' && *str_endp != '\n')) {
         return EINVAL;
     }
 


### PR DESCRIPTION
This PR adds the `msr` PMU events encoding into the sensor.
It allows to build the project on the mainline libpfm4 library (from distribution repositories) and remove the need to maintain a separate fork to add these events.