### PR TITLE
feat: Native Linux capabilities support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,7 @@
 cmake_minimum_required(VERSION 3.13)
 project(hwpc-sensor LANGUAGES CXX)
 
+option(WITH_CAPABILITY_HARDENING "Build with Linux capability hardening (retain only the required process capabilities)" ON)
 option(WITH_MONGODB "Build with support for MongoDB storage module" ON)
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
@@ -46,6 +47,11 @@ find_package(PkgConfig)
 pkg_check_modules(CZMQ REQUIRED libczmq)
 pkg_check_modules(JSONC REQUIRED json-c)
 
+if(WITH_CAPABILITY_HARDENING)
+    list(APPEND SENSOR_SOURCES src/capabilities.c)
+    add_compile_definitions(HAVE_CAPABILITY_HARDENING)
+endif()
+
 if(WITH_MONGODB)
     find_package(mongoc NAMES mongoc mongoc-1.0 REQUIRED)
     list(APPEND SENSOR_SOURCES src/storage_mongodb.c)
@@ -53,7 +59,7 @@ if(WITH_MONGODB)
     if(mongoc_VERSION VERSION_GREATER_EQUAL "2.0.0")
         set(MONGOC_LIBRARIES mongoc::shared)
     else()
-	set(MONGOC_LIBRARIES mongo::mongoc_shared)
+        set(MONGOC_LIBRARIES mongo::mongoc_shared)
     endif()
 endif()
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@
 FROM ubuntu:26.04@sha256:f3d28607ddd78734bb7f71f117f3c6706c666b8b76cbff7c9ff6e5718d46ff64 AS sensor-builder
 ENV DEBIAN_FRONTEND=noninteractive
 ARG BUILD_TYPE=Debug
+ARG CAPABILITIES_HARDENING=ON
 ARG MONGODB_SUPPORT=ON
 RUN apt update && \
     apt install -y build-essential git clang-tidy cmake pkg-config libczmq-dev libpfm4-dev libjson-c-dev libsystemd-dev uuid-dev && \
@@ -10,7 +11,11 @@ COPY . /usr/src/hwpc-sensor
 RUN cd /usr/src/hwpc-sensor && \
     GIT_TAG=$(git describe --tags --dirty 2>/dev/null || echo "unknown") \
     GIT_REV=$(git rev-parse HEAD 2>/dev/null || echo "unknown") \
-    cmake -B build -DCMAKE_BUILD_TYPE="${BUILD_TYPE}" -DCMAKE_C_CLANG_TIDY="clang-tidy" -DWITH_MONGODB="${MONGODB_SUPPORT}" && \
+    cmake -B build \
+    -DCMAKE_BUILD_TYPE="${BUILD_TYPE}" \
+    -DCMAKE_C_CLANG_TIDY="clang-tidy" \
+    -DWITH_CAPABILITY_HARDENING="${CAPABILITIES_HARDENING}" \
+    -DWITH_MONGODB="${MONGODB_SUPPORT}" && \
     cmake --build build --parallel $(getconf _NPROCESSORS_ONLN)
 
 # sensor runner image (only runtime depedencies):
@@ -18,7 +23,6 @@ FROM ubuntu:26.04@sha256:f3d28607ddd78734bb7f71f117f3c6706c666b8b76cbff7c9ff6e57
 ENV DEBIAN_FRONTEND=noninteractive
 ARG BUILD_TYPE=Debug
 ARG MONGODB_SUPPORT=ON
-ARG FILE_CAPABILITY=CAP_SYS_ADMIN
 RUN useradd -d /opt/powerapi -m powerapi && \
     apt update && \
     apt install -y libczmq4 libpfm4 libjson-c5 libcap2-bin && \
@@ -26,8 +30,7 @@ RUN useradd -d /opt/powerapi -m powerapi && \
     echo "${BUILD_TYPE}" |grep -iq "debug" && apt install -y libasan8 libubsan1 || true && \
     rm -rf /var/lib/apt/lists/*
 COPY --from=sensor-builder /usr/src/hwpc-sensor/build/hwpc-sensor /usr/bin/hwpc-sensor
-RUN setcap "${FILE_CAPABILITY}+ep" /usr/bin/hwpc-sensor && \
-    setcap -v "${FILE_CAPABILITY}+ep" /usr/bin/hwpc-sensor
+RUN setcap "cap_perfmon=p" /usr/bin/hwpc-sensor
 COPY docker/entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["--help"]

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,13 +1,3 @@
 #!/bin/bash
 
-# Check if the capabilities associated to the executable are available from the current Bounding set.
-# The Bounding set is used because the Permitted/Inheritable/Effective sets are cleared when we switch to an unprivileged user in the image.
-#
-REQUIRED_CAP=$(/sbin/getcap /usr/bin/hwpc-sensor |sed -e 's/.*\(cap_.*\)[+=].*$/\1/')
-REQUIRED_CAP_AVAILABLE=$([ -n "${REQUIRED_CAP}" ] && /sbin/capsh --print |grep "Bounding set =" |grep -iqv "${REQUIRED_CAP}" ; echo $?)
-if [ "${REQUIRED_CAP_AVAILABLE}" -eq 0 ]; then
-    echo >&2 "ERROR: This program requires the '${REQUIRED_CAP^^}' capability to work."
-    exit 1
-fi
-
 exec /usr/bin/hwpc-sensor "$@"

--- a/src/capabilities.c
+++ b/src/capabilities.c
@@ -1,0 +1,65 @@
+/*
+ *  Copyright (c) 2026, Inria
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ *  * Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ *  FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ *  DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ *  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ *  OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ *  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <linux/capability.h>
+#include <sys/syscall.h>
+#include <unistd.h>
+#include <errno.h>
+#include <string.h>
+#include <czmq.h>
+
+#define CAPSET_ADD(data, cap)                                                \
+    do {                                                                     \
+        unsigned int idx = CAP_TO_INDEX(cap);                                \
+        __u32 mask = CAP_TO_MASK(cap);                                       \
+        (data)[idx].effective |= mask;                                       \
+        (data)[idx].permitted |= mask;                                       \
+    } while (0)
+
+int
+capabilities_initialize(void)
+{
+    struct __user_cap_header_struct header;
+    struct __user_cap_data_struct data[_LINUX_CAPABILITY_U32S_3];
+
+    memset(&header, 0, sizeof(header));
+    header.version = _LINUX_CAPABILITY_VERSION_3;
+    header.pid = 0;
+
+    memset(data, 0, sizeof(data));
+    CAPSET_ADD(data, CAP_PERFMON);
+
+    if (syscall(SYS_capset, &header, &data) == -1) {
+        zsys_error("capabilities: Failed to enable required process capabilities: %s", strerror(errno));
+        return -1;
+    }
+
+    return 0;
+}

--- a/src/capabilities.h
+++ b/src/capabilities.h
@@ -1,0 +1,40 @@
+/*
+ *  Copyright (c) 2026, Inria
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ *  * Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ *  FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ *  DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ *  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ *  OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ *  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef CAPABILITIES_H
+#define CAPABILITIES_H
+
+/*
+ * capabilities_initialize setup the required Linux capabilities for the application.
+ * Unnecessary capabilities will be dropped after calling this function.
+ */
+int capabilities_initialize(void);
+
+#endif /* CAPABILITIES_H */

--- a/src/sensor.c
+++ b/src/sensor.c
@@ -52,6 +52,10 @@
 #include "storage_csv.h"
 #include "storage_socket.h"
 
+#ifdef HAVE_CAPABILITY_HARDENING
+#include "capabilities.h"
+#endif
+
 #ifdef HAVE_MONGODB
 #include "storage_mongodb.h"
 #endif
@@ -158,6 +162,14 @@ main(int argc, char **argv)
 	    goto cleanup;
     }
     zsys_info("uname: %s %s %s %s", kernel_info.sysname, kernel_info.release, kernel_info.version, kernel_info.machine);
+
+#ifdef HAVE_CAPABILITY_HARDENING
+    /* setup required process capabilities */
+    if (capabilities_initialize()) {
+        zsys_error("capabilities: Failed to initialize process capabilities. Ensure CAP_PERFMON is present in the permitted capability set.");
+        goto cleanup;
+    }
+#endif
 
     /* check if perf_event is working */
     if (perf_try_global_counting_event_open()) {


### PR DESCRIPTION
This pull request adds native Linux capabilities support to the application and simplifies capability management in the container image.

Note: The default required capability is now `CAP_PERFMON` instead of `CAP_SYS_ADMIN`.