### PR TITLE
feat(rlimits): Set nofile soft limit to hard limit on startup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,7 @@ set(SENSOR_SOURCES
     src/storage_null.c
     src/storage_csv.c
     src/storage_socket.c
+    src/rlimits.c
     src/sensor.c
 )
 

--- a/src/rlimits.c
+++ b/src/rlimits.c
@@ -1,0 +1,62 @@
+/*
+ *  Copyright (c) 2026, Inria
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ *  * Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ *  FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ *  DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ *  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ *  OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ *  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <sys/resource.h>
+#include <errno.h>
+#include <czmq.h>
+
+#include "rlimits.h"
+
+int
+rlimits_initialize(void)
+{
+    struct rlimit nofile_limit;
+    rlim_t old_nofile_soft_limit;
+
+    if (getrlimit(RLIMIT_NOFILE, &nofile_limit)) {
+        zsys_error("rlimits: Failed to get current open files (nofile) limits: %s", strerror(errno));
+        return -1;
+    }
+
+    zsys_info("rlimits: Current open files (nofile) limits: soft=%lu hard=%lu", nofile_limit.rlim_cur, nofile_limit.rlim_max);
+
+    if (nofile_limit.rlim_cur == nofile_limit.rlim_max)
+        return 0;
+
+    old_nofile_soft_limit = nofile_limit.rlim_cur;
+    nofile_limit.rlim_cur = nofile_limit.rlim_max;
+    if (setrlimit(RLIMIT_NOFILE, &nofile_limit)) {
+        zsys_error("rlimits: Failed to raise open files (nofile) soft limit: %s", strerror(errno));
+        return -1;
+    }
+
+    zsys_info("rlimits: Raised open files (nofile) soft limit from %lu to %lu", old_nofile_soft_limit, nofile_limit.rlim_max);
+    return 0;
+}

--- a/src/rlimits.h
+++ b/src/rlimits.h
@@ -1,0 +1,39 @@
+/*
+ *  Copyright (c) 2026, Inria
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ *  * Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ *  FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ *  DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ *  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ *  OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ *  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef RLIMITS_H
+#define RLIMITS_H
+
+/*
+ * rlimit_initialize setup the resource limits for the process.
+ */
+int rlimits_initialize(void);
+
+#endif /* RLIMIT_H */

--- a/src/sensor.c
+++ b/src/sensor.c
@@ -39,6 +39,7 @@
 #include <czmq.h>
 
 #include "version.h"
+#include "rlimits.h"
 #include "config.h"
 #include "config_cli.h"
 #include "pmu.h"
@@ -162,6 +163,10 @@ main(int argc, char **argv)
 	    goto cleanup;
     }
     zsys_info("uname: %s %s %s %s", kernel_info.sysname, kernel_info.release, kernel_info.version, kernel_info.machine);
+
+    if (rlimits_initialize()) {
+        goto cleanup;
+    }
 
 #ifdef HAVE_CAPABILITY_HARDENING
     /* setup required process capabilities */


### PR DESCRIPTION
Raise the process open files (nofile) soft limit to the inherited hard limit during sensor startup. This lets the sensor use the full file descriptor budget provided by the service/container runtime and fails early if the limit cannot be applied.