### PR TITLE
feat: Decouple perf sampling ticks from cgroup discovery

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,6 +40,7 @@ set(SENSOR_SOURCES
     src/storage_csv.c
     src/storage_socket.c
     src/rlimits.c
+    src/ticker.c
     src/sensor.c
 )
 

--- a/src/config.c
+++ b/src/config.c
@@ -53,7 +53,8 @@ config_create(void)
 
     /* sensor default config */
     config->sensor.verbose = 0;
-    config->sensor.frequency = 1000;
+    config->sensor.perf_sampling_interval_ms = 1000;
+    config->sensor.cgroup_discovery_interval_ms = 5000;
     snprintf(config->sensor.cgroup_basepath, PATH_MAX, "%s", "/sys/fs/cgroup");
     gethostname(config->sensor.name, HOST_NAME_MAX);
 
@@ -132,6 +133,16 @@ config_validate(struct config *config)
     }
 
     if (check_cgroup_basepath(sensor->cgroup_basepath)) {
+        return -1;
+    }
+
+    if (sensor->perf_sampling_interval_ms == 0) {
+        zsys_error("config: Perf sampling interval must be greater than 0");
+        return -1;
+    }
+
+    if (sensor->cgroup_discovery_interval_ms == 0) {
+        zsys_error("config: Cgroup discovery interval must be greater than 0");
         return -1;
     }
 

--- a/src/config.h
+++ b/src/config.h
@@ -45,7 +45,8 @@
 struct config_sensor
 {
     unsigned int verbose;
-    unsigned int frequency;
+    unsigned int perf_sampling_interval_ms;
+    unsigned int cgroup_discovery_interval_ms;
     char cgroup_basepath[PATH_MAX];
     char name[HOST_NAME_MAX];
 };

--- a/src/config_cli.c
+++ b/src/config_cli.c
@@ -40,9 +40,15 @@
 #include "util.h"
 
 
+enum {
+    OPT_CGROUP_DISCOVERY_INTERVAL = 256,
+};
+
 const char short_opts[] = "x:vf:p:n:s:c:e:or:U:D:C:P:";
 static struct option long_opts[] = {
     {"config-file", required_argument, 0, 'x'},
+    {"perf-sampling-interval", required_argument, 0, 'f'},
+    {"cgroup-discovery-interval", required_argument, 0, OPT_CGROUP_DISCOVERY_INTERVAL},
     {NULL, 0, NULL, 0}
 };
 
@@ -94,16 +100,30 @@ setup_sensor_name(struct config *config, const char *sensor_name)
 }
 
 static int
-setup_frequency(struct config *config, const char *value_str)
+setup_perf_sampling_interval(struct config *config, const char *value_str)
 {
-    unsigned int frequency;
+    unsigned int perf_sampling_interval;
 
-    if (str_to_uint(value_str, &frequency)) {
-        zsys_error("config: cli: Frequency value is invalid");
+    if (str_to_uint(value_str, &perf_sampling_interval)) {
+        zsys_error("config: cli: Perf sampling interval value is invalid");
         return -1;
     }
 
-    config->sensor.frequency = frequency;
+    config->sensor.perf_sampling_interval_ms = perf_sampling_interval;
+    return 0;
+}
+
+static int
+setup_cgroup_discovery_interval(struct config *config, const char *value_str)
+{
+    unsigned int cgroup_discovery_interval;
+
+    if (str_to_uint(value_str, &cgroup_discovery_interval)) {
+        zsys_error("config: cli: Cgroup discovery interval value is invalid");
+        return -1;
+    }
+
+    config->sensor.cgroup_discovery_interval_ms = cgroup_discovery_interval;
     return 0;
 }
 
@@ -320,7 +340,13 @@ config_setup_from_cli(int argc, char **argv, struct config *config)
             break;
 
             case 'f':
-            if (setup_frequency(config, optarg)) {
+            if (setup_perf_sampling_interval(config, optarg)) {
+                return -1;
+            }
+            break;
+
+            case OPT_CGROUP_DISCOVERY_INTERVAL:
+            if (setup_cgroup_discovery_interval(config, optarg)) {
                 return -1;
             }
             break;

--- a/src/config_json.c
+++ b/src/config_json.c
@@ -88,18 +88,34 @@ setup_sensor_name(struct config *config, json_object *sensor_name_obj)
 }
 
 static int
-setup_frequency(struct config *config, json_object *frequency_obj)
+setup_perf_sampling_interval(struct config *config, json_object *frequency_obj)
 {
-    int frequency;
+    int perf_sampling_interval = -1;
 
     errno = 0;
-    frequency = json_object_get_int(frequency_obj);
-    if (errno != 0 || frequency < 0) {
-        zsys_error("config: json: Frequency value is invalid (positive integer expected)");
+    perf_sampling_interval = json_object_get_int(frequency_obj);
+    if (errno != 0 || perf_sampling_interval <= 0) {
+        zsys_error("config: json: Perf sampling interval value is invalid (positive integer expected)");
         return -1;
     }
 
-    config->sensor.frequency = (unsigned int) frequency;
+    config->sensor.perf_sampling_interval_ms = (unsigned int) perf_sampling_interval;
+    return 0;
+}
+
+static int
+setup_cgroup_discovery_interval(struct config *config, json_object *frequency_obj)
+{
+    int cgroup_discovery_interval = -1;
+
+    errno = 0;
+    cgroup_discovery_interval = json_object_get_int(frequency_obj);
+    if (errno != 0 || cgroup_discovery_interval <= 0) {
+        zsys_error("config: json: Cgroup discovery interval value is invalid (positive integer expected)");
+        return -1;
+    }
+
+    config->sensor.cgroup_discovery_interval_ms = (unsigned int) cgroup_discovery_interval;
     return 0;
 }
 
@@ -385,8 +401,13 @@ process_json_fields(struct config *config, json_object *root)
                 return -1;
             }
         }
-        else if (!strcasecmp(key, "frequency")) {
-            if (setup_frequency(config, value)) {
+        else if (!strcasecmp(key, "frequency") || !strcasecmp(key, "perf-sampling-interval")) {
+            if (setup_perf_sampling_interval(config, value)) {
+                return -1;
+            }
+        }
+        else if (!strcasecmp(key, "cgroup-discovery-interval")) {
+            if (setup_cgroup_discovery_interval(config, value)) {
                 return -1;
             }
         }

--- a/src/sensor.c
+++ b/src/sensor.c
@@ -47,6 +47,7 @@
 #include "hwinfo.h"
 #include "perf.h"
 #include "report.h"
+#include "ticker.h"
 #include "target.h"
 #include "storage.h"
 #include "storage_null.h"
@@ -139,7 +140,8 @@ main(int argc, char **argv)
     zactor_t *reporting = NULL;
     zhashx_t *cgroups_running = NULL; /* char *cgroup_name -> char *cgroup_absolute_path */
     zhashx_t *container_monitoring_actors = NULL; /* char *actor_name -> zactor_t *actor */
-    zsock_t *ticker = NULL;
+    struct ticker_config *ticker_conf = NULL;
+    zactor_t *ticker = NULL;
     struct target *system_target = NULL;
     struct perf_config *system_monitor_config = NULL;
     zactor_t *system_perf_monitor = NULL;
@@ -258,8 +260,9 @@ main(int argc, char **argv)
     };
     reporting = zactor_new(reporting_actor, &reporting_conf);
 
-    /* create ticker publisher socket */
-    ticker = zsock_new_pub("inproc://ticker");
+    /* start ticker actor */
+    ticker_conf = ticker_config_create(config->sensor.perf_sampling_interval_ms);
+    ticker = zactor_new(ticker_actor, ticker_conf);
 
     /* start system monitoring actor only when needed */
     if (zhashx_size(config->events.system)) {
@@ -277,10 +280,7 @@ main(int argc, char **argv)
             sync_cgroups_running_monitored(hwinfo, config->events.containers, config->sensor.cgroup_basepath, container_monitoring_actors);
         }
 
-        /* send clock tick to monitoring actors */
-        zsock_send(ticker, "s8", "CLOCK_TICK", zclock_time());
-
-        zclock_sleep((int)config->sensor.frequency);
+        zclock_sleep((int)config->sensor.cgroup_discovery_interval_ms);
     }
 
     /* clean storage module ressources */
@@ -289,12 +289,12 @@ main(int argc, char **argv)
     ret = 0;
 
 cleanup:
+    zactor_destroy(&ticker);
     zhashx_destroy(&cgroups_running);
     zhashx_destroy(&container_monitoring_actors);
     zactor_destroy(&system_perf_monitor);
     zactor_destroy(&reporting);
     storage_module_destroy(storage);
-    zsock_destroy(&ticker);
     config_destroy(config);
     pmu_topology_destroy(sys_pmu_topology);
     pmu_deinitialize();

--- a/src/sensor.c
+++ b/src/sensor.c
@@ -283,9 +283,6 @@ main(int argc, char **argv)
         zclock_sleep((int)config->sensor.cgroup_discovery_interval_ms);
     }
 
-    /* clean storage module ressources */
-    storage_module_deinitialize(storage);
-
     ret = 0;
 
 cleanup:

--- a/src/storage.c
+++ b/src/storage.c
@@ -98,6 +98,7 @@ storage_module_destroy(struct storage_module *module)
     if (!module)
         return;
 
+    (*module->deinitialize)(module);
     (*module->destroy)(module);
     free(module);
 }

--- a/src/storage_mongodb.c
+++ b/src/storage_mongodb.c
@@ -201,12 +201,12 @@ mongodb_store_report(struct storage_module *module, struct payload *payload)
 }
 
 static int
-mongodb_deinitialize(struct storage_module *module __attribute__ ((unused)))
+mongodb_deinitialize(struct storage_module *module)
 {
     struct mongodb_context *ctx = (struct mongodb_context *) module->context;
 
     if (!module->is_initialized)
-        return -1;
+        return 0;
 
     mongoc_collection_destroy(ctx->collection);
     mongoc_client_destroy(ctx->client);

--- a/src/storage_socket.c
+++ b/src/storage_socket.c
@@ -307,11 +307,12 @@ socket_deinitialize(struct storage_module *module)
     struct socket_context *ctx = (struct socket_context *) module->context;
 
     if (!module->is_initialized)
-        return -1;
+        return 0;
 
     if (ctx->socket_fd != -1)
         close(ctx->socket_fd);
 
+    module->is_initialized = false;
     return 0;
 }
 

--- a/src/ticker.c
+++ b/src/ticker.c
@@ -1,0 +1,182 @@
+/*
+ *  Copyright (c) 2026, Inria
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ *  * Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ *  FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ *  DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ *  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ *  OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ *  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <czmq.h>
+#include <sys/timerfd.h>
+#include <errno.h>
+
+#include "ticker.h"
+
+
+struct ticker_config *
+ticker_config_create(unsigned int perf_sampling_interval_ms)
+{
+    struct ticker_config *config = (struct ticker_config *) malloc(sizeof(struct ticker_config));
+
+    if (!config)
+        return NULL;
+
+    config->perf_sampling_interval_ms = perf_sampling_interval_ms;
+
+    return config;
+}
+
+void
+ticker_config_destroy(struct ticker_config *config)
+{
+    if (!config)
+        return;
+
+    free(config);
+}
+
+/*
+ * ticker_context stores the context of a ticker actor.
+ */
+struct ticker_context
+{
+    struct ticker_config *config;
+    bool terminated;
+    zsock_t *pipe;
+    zsock_t *ticker;
+    int timer_fd;
+    zpoller_t *poller;
+};
+
+static struct ticker_context *
+ticker_context_create(struct ticker_config *config, zsock_t *pipe)
+{
+    struct ticker_context *ctx = (struct ticker_context *) malloc(sizeof(struct ticker_context));
+    
+    if (!ctx)
+        return NULL;
+
+    ctx->config = config;
+    ctx->terminated = false;
+    ctx->pipe = pipe;
+    ctx->ticker = zsock_new_pub("inproc://ticker");
+    ctx->timer_fd = timerfd_create(CLOCK_MONOTONIC, TFD_CLOEXEC);
+    ctx->poller = zpoller_new(ctx->pipe, &ctx->timer_fd, NULL);
+
+    return ctx;
+}
+
+static void
+ticker_context_destroy(struct ticker_context *ctx)
+{
+    if (!ctx)
+        return;
+    
+    zpoller_destroy(&ctx->poller);
+    zsock_destroy(&ctx->ticker);
+    close(ctx->timer_fd);
+    free(ctx);
+}
+
+static int
+start_timerfd(const struct ticker_context *ctx)
+{
+    struct timespec interval = {
+        .tv_sec = ctx->config->perf_sampling_interval_ms / 1000,
+        .tv_nsec = (long) (ctx->config->perf_sampling_interval_ms % 1000) * 1000000L,
+    };
+    const struct itimerspec spec = { .it_interval = interval, .it_value = interval };
+
+    if (timerfd_settime(ctx->timer_fd, 0, &spec, NULL) == -1) {
+        zsys_error("ticker: Failed to start timerfd: %s", strerror(errno));
+        return -1;
+    }
+
+    return 0;
+}
+
+static void
+handle_pipe(struct ticker_context *ctx)
+{
+    char *command = zstr_recv(ctx->pipe);
+
+    if (streq(command, "$TERM")) {
+        ctx->terminated = true;
+        zsys_info("ticker: bye!");
+    }
+    else
+        zsys_error("ticker: Invalid pipe command: %s", command);
+
+    zstr_free(&command);
+}
+
+static void
+handle_timerfd(struct ticker_context *ctx)
+{
+    uint64_t expirations = 0;
+
+    if (read(ctx->timer_fd, &expirations, sizeof(expirations)) != sizeof(expirations)) {
+        zsys_error("ticker: Failed to read timerfd: %s", strerror(errno));
+        return;
+    }
+
+    if (expirations > 1)
+        zsys_warning("ticker: Missed %" PRIu64 " tick periods", expirations - 1);
+
+    zsock_send(ctx->ticker, "s8", "CLOCK_TICK", zclock_time());
+}
+
+void ticker_actor(zsock_t *pipe, void *args)
+{
+    struct ticker_config *config = (struct ticker_config *) args;
+    struct ticker_context *ctx = ticker_context_create(config, pipe);
+    void *which = NULL;  /* The poller mixes ZMQ sockets and a raw timer fd handle. */
+
+    if (!ctx) {
+        zsys_error("ticker: Failed to create actor context");
+        return;
+    }
+
+    zsock_signal(pipe, 0);
+
+    if (start_timerfd(ctx))
+        goto cleanup;
+
+    while (!ctx->terminated) {
+        which = zpoller_wait(ctx->poller, -1);
+
+        if (zpoller_terminated(ctx->poller))
+            break;
+
+        if (which == ctx->pipe)
+            handle_pipe(ctx);
+        else if (which == &ctx->timer_fd)
+            handle_timerfd(ctx);
+    }
+
+cleanup:
+    ticker_context_destroy(ctx);
+    ticker_config_destroy(config);
+}

--- a/src/ticker.h
+++ b/src/ticker.h
@@ -1,0 +1,60 @@
+/*
+ *  Copyright (c) 2026, Inria
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ *  * Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ *  FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ *  DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ *  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ *  OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ *  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef TICKER_H
+#define TICKER_H
+
+#include <czmq.h>
+
+
+/*
+ * ticker_config stores the configuration of a ticker actor.
+ */
+struct ticker_config
+{
+    unsigned int perf_sampling_interval_ms;
+};
+
+/*
+ * ticker_config_create allocate the resource of a ticker actor configuration.
+ */
+struct ticker_config* ticker_config_create(unsigned int perf_sampling_interval_ms);
+
+/*
+ * ticker_config_destroy free the allocated resource of the ticker actor configuration.
+ */
+void ticker_config_destroy(struct ticker_config *config);
+
+/*
+ * ticker_actor is the ticker actor entrypoint.
+ */
+void ticker_actor(zsock_t *pipe, void *args);
+
+#endif /* TICKER_H */


### PR DESCRIPTION
This PR makes perf sampling timing independent from container discovery work. The sensor now uses a dedicated ticker actor for sampling ticks, while the main loop remains responsible for cgroup discovery and actor lifecycle management.

Changes overview :
  - Add a timerfd-backed ticker actor that publishes `CLOCK_TICK` messages.
  - Start the ticker actor from the sensor main flow instead of publishing ticks directly there.
  - Add configuration for controlling the cgroup discovery interval independently from perf sampling.