### PR TITLE
ci(dependabot): Group CodeQL action updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,3 +7,9 @@ updates:
       interval: "daily"
     labels:
       - "dependencies"
+    groups:
+      codeql-actions:
+        # Group CodeQL actions so they're always updated together.
+        # This prevents CodeQL checks from failing due to version mismatches.
+        patterns:
+          - "github/codeql-action/*"


### PR DESCRIPTION
Add a Dependabot group for CodeQL actions so their pinned versions are updated in a single pull request. This avoids failing checks caused by temporary version mismatches across separate updates.